### PR TITLE
Fix crash in Unity 2019.2.0

### DIFF
--- a/Assembly-TypeTreeTools/TypeTreeTools/ExportCommands.Legacy.cs
+++ b/Assembly-TypeTreeTools/TypeTreeTools/ExportCommands.Legacy.cs
@@ -77,7 +77,9 @@ namespace TypeTreeTools
                 if (obj == null)
                     continue;
 
-                if (obj->GetTypeTree(flags, out var tree))
+                var tree = new TypeTree();
+                tree.Init();
+                if (obj->GetTypeTree(flags, ref tree))
                 {
                     // Shouldn't this write type.PersistentTypeID instead?
                     // I'm leaving it as iter.PersistentTypeID for consistency
@@ -144,7 +146,9 @@ namespace TypeTreeTools
                 if (obj == null)
                     continue;
 
-                if (obj->GetTypeTree(flags, out var tree))
+                var tree = new TypeTree();
+                tree.Init();
+                if (obj->GetTypeTree(flags, ref tree))
                     TypeTreeUtility.CreateTextDump(tree, tw);
 
                 NativeObject.DestroyIfNotSingletonOrPersistent(obj);

--- a/Assembly-TypeTreeTools/Unity/Core/NativeObject.Bindings.cs
+++ b/Assembly-TypeTreeTools/Unity/Core/NativeObject.Bindings.cs
@@ -7,12 +7,12 @@ namespace Unity.Core
         [PdbSymbol("?GenerateTypeTree@@YAXAEBVObject@@AEAVTypeTree@@W4TransferInstructionFlags@@@Z")]
         static readonly GenerateTypeTreeDelegate s_GenerateTypeTree;
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        delegate void GenerateTypeTreeDelegate(in NativeObject obj, out TypeTree tree, TransferInstructionFlags flags);
+        delegate void GenerateTypeTreeDelegate(in NativeObject obj, ref TypeTree tree, TransferInstructionFlags flags);
 
         [PdbSymbol("?GetTypeTree@TypeTreeCache@@YA_NPEBVObject@@W4TransferInstructionFlags@@AEAVTypeTree@@@Z")]
         static readonly GetTypeTreeDelegate s_GetTypeTree;
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        delegate bool GetTypeTreeDelegate(in NativeObject obj, TransferInstructionFlags flags, out TypeTree tree);
+        delegate bool GetTypeTreeDelegate(in NativeObject obj, TransferInstructionFlags flags, ref TypeTree tree);
 
         [PdbSymbol("?GetSpriteAtlasDatabase@@YAAEAVSpriteAtlasDatabase@@XZ")]
         static readonly GetSpriteAtlasDatabaseDelegate s_GetSpriteAtlasDatabase;

--- a/Assembly-TypeTreeTools/Unity/Core/NativeObject.cs
+++ b/Assembly-TypeTreeTools/Unity/Core/NativeObject.cs
@@ -52,14 +52,14 @@ namespace Unity.Core
             set { bits[CachedTypeIndexSection] = (int)value; }
         }
 
-        public bool GetTypeTree(TransferInstructionFlags flags, out TypeTree tree)
+        public bool GetTypeTree(TransferInstructionFlags flags, ref TypeTree tree)
         {
             if (s_GetTypeTree != null)
-                return s_GetTypeTree(this, flags, out tree);
+                return s_GetTypeTree(this, flags, ref tree);
 
             if (s_GenerateTypeTree != null)
             {
-                s_GenerateTypeTree(this, out tree, flags);
+                s_GenerateTypeTree(this, ref tree, flags);
                 return true;
             }
 

--- a/Assembly-TypeTreeTools/Unity/Core/TypeTree.Bindings.cs
+++ b/Assembly-TypeTreeTools/Unity/Core/TypeTree.Bindings.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Unity.Core
+{
+    public unsafe partial struct TypeTree
+    {
+#if UNITY_2019_1 || UNITY_2019_2
+        [PdbSymbol("??0TypeTree@@QEAA@AEBUMemLabelId@@_N@Z")]
+        static readonly TypeTreeDelegate s_TypeTree;
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        delegate IntPtr* TypeTreeDelegate(ref TypeTree typeTree, ref MemLabelId memLabel, bool allocatePrivateData = false);
+#else
+        [PdbSymbol("??0TypeTree@@QEAA@AEBUMemLabelId@@@Z")]
+        static readonly TypeTreeDelegate s_TypeTree;
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        delegate IntPtr* TypeTreeDelegate(ref TypeTree typeTree, ref MemLabelId memLabel);
+#endif
+        [PdbSymbol("?kMemTypeTree@@3UMemLabelId@@A")]
+        public static MemLabelId* kMemTypeTree;
+    }
+}

--- a/Assembly-TypeTreeTools/Unity/Core/TypeTree.cs
+++ b/Assembly-TypeTreeTools/Unity/Core/TypeTree.cs
@@ -3,11 +3,25 @@ using System.Runtime.InteropServices;
 
 namespace Unity.Core
 {
-    public unsafe struct TypeTree
+    public unsafe partial struct TypeTree
     {
+#if UNITY_2019_1 || UNITY_2019_2
+        public TypeTreeShareableData* Data;
+        public TypeTreeShareableData m_PrivateData;
+#elif UNITY_2019_3_OR_NEWER
         public TypeTreeShareableData* Data;
         public IntPtr ReferencedTypes;
         [MarshalAs(UnmanagedType.U1)]
         public bool PoolOwned;
+#else
+        public DynamicArray<TypeTreeNode> Nodes;
+        public DynamicArray<byte> StringBuffer;
+        public DynamicArray<uint> ByteOffsets;
+#endif
+
+        public void Init()
+        {
+            s_TypeTree(ref this, ref *kMemTypeTree);
+        }
     }
 }

--- a/Assembly-TypeTreeTools/Unity/Core/TypeTreeNode.cs
+++ b/Assembly-TypeTreeTools/Unity/Core/TypeTreeNode.cs
@@ -10,6 +10,8 @@
         public int ByteSize;
         public int Index;
         public TransferMetaFlags MetaFlag;
+#if UNITY_2019_1_OR_NEWER
         public ulong RefTypeHash;
+#endif
     }
 }


### PR DESCRIPTION
 Fix crash in Unity 2019.2.0 by constructing TypeTree before calling GetTypeTree. I wasn't sure if it was worth the effort of calling the deconstructor afterwards or just leak memory.